### PR TITLE
Project css update

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,7 +6,7 @@ layout: default
   <div class="post-container">
     {% if page.mermaid %}
     <h4 class="project-title">{%if page.pretitle %}{{ page.pretitle }} {%endif%}{{ page.title }}{%if page.subtitle %} {{ page.subtitle }}{%endif%}</h4>
-    <div class="project-load">{{ content }}</div>
+    <div class="project-load mermaid-container-post">{{ content }}</div>
     {% else %}
     <h4 class="project-title">{{ page.title }}</h4>
     <div class="project-load">{{ content }}</div>

--- a/_sass/3-sections/_projects.sass
+++ b/_sass/3-sections/_projects.sass
@@ -4,6 +4,7 @@
   padding: 30px
   +clearfix
   .project-unit
+    border-radius: 8px
     box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23)
     cursor: pointer
     display: block

--- a/assets/css/mermaid.css
+++ b/assets/css/mermaid.css
@@ -10,6 +10,12 @@
     gap: 50px;
 }
 
+.mermaid-container-post {
+    border: 1px solid #c0c0c0;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+}
+
 .title-container {
     display: flex;
     flex-direction: column;

--- a/assets/css/mermaid.css
+++ b/assets/css/mermaid.css
@@ -3,9 +3,6 @@
 .mermaid-container {
     padding: 40px;
     margin: 20px auto;
-    border: 1px solid #c0c0c0;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
This pull request refactors how styling is applied to Mermaid diagram containers in posts and updates the appearance of project units. The main goal is to separate general Mermaid container styles from those used specifically in post layouts, and to improve the visual design of project listings.

Styling refactor for Mermaid containers:

* Moved border, box-shadow, and border-radius styles from the general `.mermaid-container` class in `assets/css/mermaid.css` to a new `.mermaid-container-post` class, ensuring these styles are only applied to Mermaid containers within posts.
* Updated `_layouts/post.html` to add the new `mermaid-container-post` class to the relevant content container when Mermaid diagrams are present, so the correct styles are applied.

Project unit appearance improvements:

* Added a `border-radius: 8px` style to `.project-unit` in `_sass/3-sections/_projects.sass` to give project cards rounded corners for a more modern look.