### PR TITLE
Fix template for short commands

### DIFF
--- a/_includes/mermaid-graphs.html
+++ b/_includes/mermaid-graphs.html
@@ -25,8 +25,14 @@
   <div class="mermaid">
     block-beta
     columns 1
-    
-    {% if command_parts.size == 3 %}
+    {% if command_parts.size == 2 %}
+    block:notes
+      space:1 f["{{ page.descriptors[0].command }}"]
+    end
+    block:command
+      a("{{ command_parts[0] }}") b("{{ command_parts[1] }}")
+    end
+    {% elsif command_parts.size == 3 %}
     block:notes
       space:2 f["{{ page.descriptors[1].part1 }}"]
     end
@@ -86,10 +92,13 @@
   {% endif %}
 
   %% arrows %%
+  {% if command_parts.size == 2 %}
+  b --> f
+  {% elsif command_parts.size == 3 %}
   b --> g
   c --> f
   classDef textFont font-family:'Chilanka', font-size:1.2em, font-color:#fff, line-height:2em;
-  {% if command_parts.size == 4 %}
+  {% elsif command_parts.size == 4 %}
   d --> h
   {% elsif command_parts.size == 5 %}
   d --> h

--- a/scripts/mermaid_generator.py
+++ b/scripts/mermaid_generator.py
@@ -46,6 +46,7 @@ class MermaidDiagramGenerator:
 
         # Use a strategy pattern based on command parts count
         generators = {
+            2: cls._generate_2_part_command,
             3: cls._generate_3_part_command,
             4: cls._generate_4_part_command,
             5: cls._generate_5_part_command,
@@ -58,6 +59,30 @@ class MermaidDiagramGenerator:
             return cls._generate_generic_command_diagram(fm)
 
         return generator(command_parts, descriptors, info)
+
+    @classmethod
+    def _generate_2_part_command(cls, command_parts: List[str], descriptors: List[Dict], info: str) -> str:
+        """Generate diagram for 2-part commands."""
+        command_desc = cls.escape_quotes(descriptors[0].get('command', '')) if len(descriptors) > 0 else ''
+
+        mermaid = "block-beta\ncolumns 1\n\n"
+        mermaid += f"""block:notes
+  space:1 f["{command_desc}"]
+end
+block:command
+  a("{cls.escape_quotes(command_parts[0])}") b("{cls.escape_quotes(command_parts[1])}")
+end
+"""
+
+        if info:
+            mermaid += f"""
+block:info
+  j["{cls.escape_quotes(info)}"]
+end
+"""
+
+        mermaid += cls._get_command_styling(len(command_parts))
+        return mermaid
 
     @classmethod
     def _generate_3_part_command(cls, command_parts: List[str], descriptors: List[Dict], info: str) -> str:
@@ -211,18 +236,18 @@ end
     def _get_command_styling(cls, num_parts: int) -> str:
         """Get styling for command diagrams based on number of parts."""
         base_styling = """
-%% arrows %%
-b --> g
-c --> f
-classDef textFont font-family:'Chilanka', font-size:1.2em, color:#000, line-height:2em;
-"""
+%% arrows %%"""
 
-        if num_parts == 4:
-            base_styling += "d --> h\n"
+        if num_parts == 2:
+            base_styling += "\nb -->f\n"
+        elif num_parts == 3:
+            base_styling += "\nb --> g\nc --> f\nclassDef textFont font-family:'Chilanka', font-size:1.2em, color:#000, line-height:2em;\n"
+        elif num_parts == 4:
+            base_styling += "\nd --> h\n"
         elif num_parts == 5:
-            base_styling += "d --> h\ne --> i\n"
+            base_styling += "\nd --> h\ne --> i\n"
         elif num_parts == 6:
-            base_styling += "d --> h\ne --> i\nk --> l\nclassDef textFont font-family:'Chilanka', font-size:1.2em, color:#000, line-height:2.2em;\n"
+            base_styling += "\nd --> h\ne --> i\nk --> l\nclassDef textFont font-family:'Chilanka', font-size:1.2em, color:#000, line-height:2.2em;\n"
 
         base_styling += """
 %% styling %%


### PR DESCRIPTION
This pull request adds support for generating and rendering diagrams for commands with two parts in the Mermaid diagram generator and its corresponding HTML template. The changes ensure that commands with two parts are handled consistently in both the Python backend and the Jekyll frontend, including correct diagram structure and arrow rendering.

Support for 2-part commands:

* Added a new method `_generate_2_part_command` in `scripts/mermaid_generator.py` to generate Mermaid diagrams for 2-part commands, and updated the generator dispatch logic to use this method. [[1]](diffhunk://#diff-08c4d17c3927c14d26788f7b9431fb1214c0c8cb1c7dc3d755c45038de4208b6R49) [[2]](diffhunk://#diff-08c4d17c3927c14d26788f7b9431fb1214c0c8cb1c7dc3d755c45038de4208b6R63-R86)
* Updated the `_get_command_styling` method in `scripts/mermaid_generator.py` to include correct arrow styling for diagrams with two parts.

Frontend template updates:

* Modified `_includes/mermaid-graphs.html` to add logic for rendering 2-part command diagrams, including notes and command blocks, and to display the correct arrows for two-part commands. [[1]](diffhunk://#diff-719cdceda9eb99ca8ced619e148eadd740a2328501c6b0f2a525b7322d13e0c2L28-R35) [[2]](diffhunk://#diff-719cdceda9eb99ca8ced619e148eadd740a2328501c6b0f2a525b7322d13e0c2R95-R101)