### PR TITLE
Add Spanish translation for card 040

### DIFF
--- a/_posts/2022-01-19-040.md
+++ b/_posts/2022-01-19-040.md
@@ -6,6 +6,8 @@ permalink: "/projects/040"
 translations:
 - lang: en
   url: /en/040
+- lang: es
+  url: /es/040
 lang: "pt"
 pv:
   url: "/projects/039"

--- a/en/_posts/2022-01-19-040.md
+++ b/en/_posts/2022-01-19-040.md
@@ -3,6 +3,8 @@ layout: post
 title: '#040 What is stash?'
 image: "https://res.cloudinary.com/jesstemporal/image/upload/v1642964722/gitfichas/en/040/thumbnail_efctyk.jpg"
 translations:
+- lang: es
+  url: /es/040
 - lang: pt
   url: /projects/040
 permalink: "/en/040"

--- a/es/_posts/2022-01-19-040.md
+++ b/es/_posts/2022-01-19-040.md
@@ -8,6 +8,7 @@ parts:
   - part2: el comando permite guardar los cambios realizados<br>y volver a un estado limpio del directorio de trabajo
   - part3: índice del stash en stash@{n}
 number: "040"
+author: "@jtemporal"
 mermaid: true
 permalink: "/es/040"
 translations:

--- a/es/_posts/2022-01-19-040.md
+++ b/es/_posts/2022-01-19-040.md
@@ -1,14 +1,11 @@
 layout: post
 pretitle: ¿Qué es
 title: stash
-
-command: git stash
-descriptors:
-- command: es un conjunto de cambios guardados<br>en una pila para usarse más tarde
-- part1: el comando permite guardar los cambios realizados<br>y volver a un estado limpio del directorio de trabajo
-- part2: índice del stash en stash@{n}
-
-
+concept: true
+parts:
+  - part1: es un conjunto de cambios guardados<br>en una pila para usarse más tarde
+  - part2: el comando permite guardar los cambios realizados<br>y volver a un estado limpio del directorio de trabajo
+  - part3: índice del stash en stash@{n}
 number: "040"
 mermaid: true
 permalink: "/es/040"

--- a/es/_posts/2022-01-19-040.md
+++ b/es/_posts/2022-01-19-040.md
@@ -1,3 +1,4 @@
+---
 layout: post
 pretitle: ¿Qué es
 title: stash

--- a/es/_posts/2022-01-19-040.md
+++ b/es/_posts/2022-01-19-040.md
@@ -1,0 +1,28 @@
+layout: post
+pretitle: ¿Qué es
+title: stash
+
+command: git stash
+descriptors:
+- command: es un conjunto de cambios guardados<br>en una pila para usarse más tarde
+- part1: el comando permite guardar los cambios realizados<br>y volver a un estado limpio del directorio de trabajo
+- part2: índice del stash en stash@{n}
+
+
+number: "040"
+mermaid: true
+permalink: "/es/040"
+translations:
+  - lang: pt
+    url: /projects/040
+  - lang: en
+    url: /en/040
+lang: "es"
+pv:
+  url: "/es/039"
+  title: "#039 git commit -C ORIG_HEAD"
+nt:
+  url: "/es/041"
+  title: "#041 git stash push"
+---
+{% include mermaid-graphs.html %}


### PR DESCRIPTION
This PR adds the Spanish version of card #251  (stash) following the new mermaid format, as outlined in CONTRIBUTING.md.

Changes included:

Created es/_posts/2022-01-19-040.md with the Spanish translation.

Linked the Spanish translation in the Portuguese (pt) and English (en) versions.

Ensured descriptors, command, and formatting follow the established card style.

This contribution ensures the stash card is accessible to Spanish-speaking users while maintaining consistency across all available languages.

fixes #251 