### PR TITLE
feat: adicionando o dockerignore para deixar a imagem docker leve

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+### Git ###
+.git
+.gitignore
+.github
+
+### OSX ###
+.AppleDouble
+.LSOverride
+
+### Files ###
+LICENSE.md
+README.md
+LICENSE
+COC.md
+MERMAID_CONVERTER_README.md
+
+### Docker ###
+Dockerfile
+
+### IDE ###
+.vscode
+.idea
+*.DS_Store
+Thumbs.db


### PR DESCRIPTION
Ao trabalhar com Docker, um dos arquivos mais importantes e muitas vezes subestimado é o .dockerignore. Este arquivo desempenha um papel crucial em otimizar o processo de build de imagens Docker, evitando que arquivos desnecessários sejam incluídos. 

### O Que é o .dockerignore?
O arquivo .dockerignore funciona de maneira semelhante ao .gitignore, sendo utilizado para especificar quais arquivos e diretórios devem ser ignorados ao construir uma imagem Docker. Isso é crucial para garantir que a imagem seja o mais leve possível e que não contenha arquivos desnecessários, como dependências locais, arquivos de configuração específicos do ambiente de desenvolvimento e outros artefatos temporários.

Fonte: https://dev.to/fernandomullerjr/importancia-do-dockerignore-e-como-utilizar-de-forma-correta-228g