### PR TITLE
feat: Add Spanish translation for card 37

### DIFF
--- a/es/_posts/2022-01-14-037.md
+++ b/es/_posts/2022-01-14-037.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: '#037 git reset HEAD^'
+image: "https://res.cloudinary.com/jesstemporal/image/upload/f_auto/v1642878600/gitfichas/en/037/thumbnail_vjzfwl.jpg"
+permalink: "/es/037"
+translations:
+- lang: pt
+  url: /projects/037
+lang: "es"
+pv:
+  url: "/es/036"
+  title: "#036 git reset HEAD~3"
+nt:
+  url: "/es/038"
+  title: "#038 git reset HEAD^ --soft"
+---
+
+<img alt="El comando git reset HEAD seguido de ^ es un atajo para deshacer el último commit realizado." src="https://res.cloudinary.com/jesstemporal/image/upload/v1642878601/gitfichas/en/037/full_dko55b.jpg"><br><br>
+
+| Comando           | Descripción                                      |
+| ----------------- | ------------------------------------------------- |
+| `reset`         | Comando que restaura a un estado anterior         |
+| `HEAD`          | Puntero que guarda el estado actual               |
+| `^`             | El circunflejo es un atajo para el último commit |
+{: .styled-table}                 
+
+<!--
+<br>
+También te puede interesar leer este artículo:
+
+<a href="https://jtemporal.com/criando-um-novo-branch-e-mudando-pra-ele-com-um-comando/">
+  <strong>Creando una nueva rama y cambiando a ella con un solo comando</strong>
+</a>
+-->


### PR DESCRIPTION
This pull request adds a new Spanish-language post explaining the `git reset HEAD^` command. The post includes a description, usage table, and related navigation.

New Spanish post:

* Added `es/_posts/2022-01-14-037.md` with an explanation of the `git reset HEAD^` command, including a command table, image, navigation to previous/next posts, and translation metadata.