### PR TITLE
fix incorrect "lang" in card es 32

### DIFF
--- a/es/_posts/2022-01-06-032.md
+++ b/es/_posts/2022-01-06-032.md
@@ -15,7 +15,7 @@ permalink: "/es/032"
 translations:
 - lang: pt
   url: /projects/032
-lang: "en"
+lang: "es"
 pv:
   url: "/es/031"
   title: "#031 git commit --amend"


### PR DESCRIPTION
Related to my PR #333

Noticed that in es 032 - I had incorrectly kept lang value to "en" instead of "es". 

Fixed in this PR :)

Before - The "es/032" - is pointing to english version of the website (and changing from en to es takes to spanish home page - instead of opening the 032 spanish card)

<img width="1919" height="955" alt="image" src="https://github.com/user-attachments/assets/67a47a45-5e9d-4332-94a6-3fb9b2568677" />

After - Now "es/032" is correctly pointing to spanish version of the website

<img width="1919" height="901" alt="image" src="https://github.com/user-attachments/assets/da5515b1-b715-4702-a54d-e94920fc1be5" />


CC: @jtemporal 