### PR TITLE
fix 'nt' link and add 'en' translation in Spanish 032 card

### DIFF
--- a/es/_posts/2022-01-06-032.md
+++ b/es/_posts/2022-01-06-032.md
@@ -15,12 +15,14 @@ permalink: "/es/032"
 translations:
 - lang: pt
   url: /projects/032
+- lang: en
+  url: /en/032
 lang: "es"
 pv:
   url: "/es/031"
   title: "#031 git commit --amend"
 nt:
-  url: "/es/032"
+  url: "/es/033"
   title: "#033 ggit clonar url nombre"
 ---
 


### PR DESCRIPTION
This fixes the below issue in Spanish card 032
- The next link is still pointing to 032 - fixed that to point 033 card
- Add english translation link

(Related to previous closed issues #243 #340 )

CC: @jtemporal 