### PR TITLE
Update 2022-01-06-032.md

### DIFF
--- a/es/_posts/2022-01-06-032.md
+++ b/es/_posts/2022-01-06-032.md
@@ -23,7 +23,7 @@ pv:
   title: "#031 git commit --amend"
 nt:
   url: "/es/033"
-  title: "#033 ggit clonar url nombre"
+  title: "#033 git clonar url nombre"
 ---
 
 {% include mermaid-graphs.html %}


### PR DESCRIPTION
Fix typo in Spanish card #033: remove extra “g” so title is #033 git clonar url nombre. 
Fixes #364 