### PR TITLE
Docs: fix links and typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 | Table of content | Índice |
 | ------- | --------- |
-| &nbsp;&nbsp;• [Before You Start](#before-you-start)<br>&nbsp;&nbsp;• [Code of Conduct](#code-of-conduct)<br>&nbsp;&nbsp;• [Cards Types](#cards-types)<br>&nbsp;&nbsp;• [File Naming Convention](#file-naming-convention)<br>&nbsp;&nbsp;• [Running the Project](#running-the-project)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Local way](#local-way)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Install dependencies](#install-dependencies)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Run the project](#run-the-project)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Docker way](#docker-way)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Building image](#building-image)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Serving](#serving)<br>&nbsp;&nbsp;• [Working with Mermaid Diagrams](#working-with-mermaid-diagrams)<br>&nbsp;&nbsp;• [The Basics of Contributing](#the-basics-of-contributing)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [The Git basics](#the-git-basics)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Issue Assignment](#issue-assignment) | &nbsp;&nbsp;• [Antes de Começar](#antes-de-começar)<br>&nbsp;&nbsp;• [Código de Conduta](#código-de-conduta)<br>&nbsp;&nbsp;• [Tipos de Fichas](#tipos-de-fichas)<br>&nbsp;&nbsp;• [Convenção de Nomes de Arquivos](#convenção-de-nomes-de-arquivos)<br>&nbsp;&nbsp;• [Rodando o Projeto](#rodando-o-projeto)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Localmente](#localmente)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Instalando depedências](#instalando-depedências)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Rodar o projeto](#rodar-o-projeto)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Com Docker](#com-docker)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Montando a imagem](#montando-a-imagem)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Servindo](#servindo)<br>&nbsp;&nbsp;• [Trabalhando com Diagramas Mermaid](#trabalhando-com-diagramas-mermaid)<br>&nbsp;&nbsp;• [Fazendo Contribuições](#fazendo-contribuições)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [O básico de git](#o-básico-de-git)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Atribuição de issues](#atribuição-de-issues) |
+| &nbsp;&nbsp;• [Before You Start](#before-you-start)<br>&nbsp;&nbsp;• [Code of Conduct](#code-of-conduct)<br>&nbsp;&nbsp;• [Cards Types](#cards-types)<br>&nbsp;&nbsp;• [File Naming Convention](#file-naming-convention)<br>&nbsp;&nbsp;• [Running the Project](#running-the-project)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Local way](#local-way)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Install dependencies](#install-dependencies)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Run the project](#run-the-project)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Docker way](#docker-way)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Building image](#building-image)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Serving](#serving)<br>&nbsp;&nbsp;• [Working with Mermaid Diagrams](#working-with-mermaid-diagrams)<br>&nbsp;&nbsp;• [The Basics of Contributing](#the-basics-of-contributing)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [The Git basics](#the-git-basics)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Issue Assignment](#issue-assignment) | &nbsp;&nbsp;• [Antes de Começar](#antes-de-começar)<br>&nbsp;&nbsp;• [Código de Conduta](#código-de-conduta)<br>&nbsp;&nbsp;• [Tipos de Fichas](#tipos-de-fichas)<br>&nbsp;&nbsp;• [Convenção de Nomes de Arquivos](#convenção-de-nomes-de-arquivos)<br>&nbsp;&nbsp;• [Rodando o Projeto](#rodando-o-projeto)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Localmente](#localmente)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Instalando dependências](#instalando-dependências)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Rodar o projeto](#rodar-o-projeto)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Com Docker](#com-docker)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Montando a imagem](#montando-a-imagem)<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• [Servindo](#servindo)<br>&nbsp;&nbsp;• [Trabalhando com Diagramas Mermaid](#trabalhando-com-diagramas-mermaid)<br>&nbsp;&nbsp;• [Fazendo Contribuições](#fazendo-contribuições)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [O básico de git](#o-básico-de-git)<br>&nbsp;&nbsp;&nbsp;&nbsp;• [Atribuição de issues](#atribuição-de-issues) |
 
 ## Before You Start
 
@@ -20,9 +20,9 @@ If you have any questions create an issue.
 
 ## Code of Conduct
 
-GitFichas is a welcoming and inclusive space for everyone. All contributors are expected to follow our [Code of Conduct](https://github.com/jtemporal/gitfichas/blob/main/CONTRIBUTING.md). Please take a moment to read it and help us maintain a positive environment for all.
+GitFichas is a welcoming and inclusive space for everyone. All contributors are expected to follow our [Code of Conduct](https://github.com/jtemporal/gitfichas/blob/main/COC.md#code-of-conduct). Please take a moment to read it and help us maintain a positive environment for all.
 
-[Read the full Code of Conduct](https://github.com/jtemporal/gitfichas/blob/main/CONTRIBUTING.md).
+[Read the full Code of Conduct](https://github.com/jtemporal/gitfichas/blob/main/COC.md#code-of-conduct).
 
 ## Cards Types
 
@@ -419,9 +419,9 @@ Se tiver alguma dúvida, crie uma issue.
 
 ## Código de Conduta
 
-O GitFichas é um espaço acolhedor e inclusivo para todas pessoas. Isso quer dizer que devemos seguir nosso [Código de Conduta](https://github.com/jtemporal/gitfichas/blob/main/CONTRIBUTING.md). Por favor, leia-o com atenção antes de contribuir.
+O GitFichas é um espaço acolhedor e inclusivo para todas pessoas. Isso quer dizer que devemos seguir nosso [Código de Conduta](https://github.com/jtemporal/gitfichas/blob/main/COC.md#c%C3%B3digo-de-conduta). Por favor, leia-o com atenção antes de contribuir.
 
-[Leia o Código de Conduta completo](https://github.com/jtemporal/gitfichas/blob/main/CONTRIBUTING.md).
+[Leia o Código de Conduta completo](https://github.com/jtemporal/gitfichas/blob/main/COC.md#c%C3%B3digo-de-conduta).
 
 ## Tipos de Fichas
 
@@ -572,7 +572,7 @@ O devcontainer inclui:
 
 Instale o [Bundler](https://bundler.io/guides/getting_started.html) e siga os passos abaixo.
 
-#### Instalando depedências
+#### Instalando dependências
 
 ```console
 bundle install


### PR DESCRIPTION
This pull request makes minor improvements to the CONTRIBUTING.md file:
- Fixes links that were incorrectly pointing to the Code of Conduct
- Corrects a typo found in the text

These changes aim to improve clarity and ensure that contributors can easily find the correct resources when contributing to the project