### PR TITLE
Add multilingual search placeholders and no-results messages

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -18,6 +18,17 @@ menu:
   - {name: 'Acerca',   url: 'acerca'}
 #  - {name: 'Libro',    url: 'https://jtemporal.com/microlivrodegit?utm_source=gitfichas'}
 
+search:
+  pt:
+    placeholder: 'Busque fichas...'
+    no_results: 'Nenhuma ficha corresponde à sua busca!'
+  en:
+    placeholder: 'Search cards...'
+    no_results: 'No cards match your search!'
+  es:
+    placeholder: 'Busca tarjetas...'
+    no_results: '¡Ninguna tarjeta coincide con tu búsqueda!'
+
 #-------------------------------
 # Contact Section
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,13 +22,14 @@ layout: default
   </div>
 
   <!-- Search Bar -->
+  {% assign search_strings = site.data.settings.search[current_lang] | default: site.data.settings.search[site.default_language] %}
   <div class="search-container">
-      <input type="text" id="search-input" placeholder="Search cards...">
+      <input type="text" id="search-input" placeholder="{{ search_strings.placeholder }}">
   </div>
 
   <!-- hidden by default, visible when no cards match seach query -->
   <div id="no-results-message" class="no-results-message">
-        No cards match your search! 
+        {{ search_strings.no_results }}
   </div>
 
   <div class="project-container">


### PR DESCRIPTION
## Summary
- add localized search bar strings (placeholder and empty state) to `_data/settings.yml` so they can follow the active locale
- read the localized strings in `_layouts/home.html` and fall back to the default language when needed

fix #423

## Testing
- [x] `bundle exec jekyll serve`
  - visit `/`, `/en`, `/es` to confirm placeholder and no-results text match the page language

## Screenshots 📸 

### Portuguese 🇧🇷 

<img width="2864" height="1732" alt="screenshot-2025-10-18_11-12-03" src="https://github.com/user-attachments/assets/c8d76eee-406a-45d9-bd1d-b16b95cbd99a" />

### Spanish 🇪🇸 

<img width="2864" height="1732" alt="screenshot-2025-10-18_11-13-04" src="https://github.com/user-attachments/assets/972344f6-493f-4c60-a414-7129250ab0bf" />

### English 🇺🇸 

<img width="2864" height="1732" alt="screenshot-2025-10-18_11-13-41" src="https://github.com/user-attachments/assets/964fae07-cf98-44ce-9aca-74509aab7cdb" />
